### PR TITLE
Fix extraneous quote in schema_dumper

### DIFF
--- a/lib/active_record/pg_enum/schema_dumper.rb
+++ b/lib/active_record/pg_enum/schema_dumper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         stream.puts "  # These are custom enum types that must be created before they can be used in the schema definition"
 
         enum_types.each do |name, definition|
-          stream.puts %Q{  create_enum "#{name}", %w[#{definition.join(" ")}]"}
+          stream.puts %Q{  create_enum "#{name}", %w[#{definition.join(" ")}]}
         end
 
         stream.puts


### PR DESCRIPTION
Thanks for this great extension!

There's a slight typo in the schema dumper that's causing syntax errors for me. This PR just removes the extraneous `"` symbol from that line.